### PR TITLE
Making ggram accept any geom

### DIFF
--- a/R/ggram.R
+++ b/R/ggram.R
@@ -10,6 +10,8 @@
 #' @param smoothing smoothing paramater, default is 3
 #' @param wide a logical value indicating whether results should be returned 
 #'   in a "wide" format (phrases are column names) or not. The default is \code{FALSE}.
+#' @param geom the ggplot2 geom used to plot the data; defaults to "line"
+#' @param ... any other argument passed to the ggplot2 geom
 #' @details 
 #'  Google generated two datasets drawn from digitised books in the Google
 #'  books collection. One was generated in July 2009, the second in July 2012.


### PR DESCRIPTION
These changes make `ggram` accept any ggplot2 geom. The example below uses `step`.

![rplot](https://f.cloud.github.com/assets/322533/829106/0788b694-f0c8-11e2-81b7-94e3fe9beeae.png)

```
ggram(c("cancer", "fumer", "cigarette"),
      year_start = 1900,
      corpus = "fre_2012", 
      geom = "step")
```

Two examples to illustrate this change have been added to the documentation.
