### PR TITLE
fix labels

### DIFF
--- a/R/ggram.R
+++ b/R/ggram.R
@@ -51,7 +51,7 @@ ggram <- function(phrases, ignore.case=FALSE, geom="line", geom_options=list(), 
   if (!is.null(geom)) p <- p + do.call(stat_identity, c(geom = geom, geom_options))
   p <-  p + labs(x = NULL) + 
     scale_y_continuous(labels = percent) + 
-    scale_colour_discrete("")
+    scale_colour_discrete("", labels = phrases)
   return(p)
 }
 


### PR DESCRIPTION
The discrete scale needs labels to be manually set to preserve upper case in the keywords. Here's an example:

```
ggram(c("USSR", "Russia"),
      year_start = 1900,
      corpus = "eng_gb_2012", 
      geom = "area",
      geom_options = list(position = "stack"),
      ignore.case = TRUE) + 
  aes_string(fill = "Phrase") + 
  scale_x_continuous(breaks = 1900 + 10*0:11) +
  scale_fill_discrete("", labels = c("USSR", "Russia"))
```

![](http://i.imgur.com/ALCfdrs.png)
