### PR TITLE
Changed getURL() to equivalent GET() call.

### DIFF
--- a/R/ngram.R
+++ b/R/ngram.R
@@ -123,7 +123,7 @@ ngram_fetch <- function(phrases, corpus, year_start,  year_end, smoothing, case_
   ng_url <- ngram_url(phrases, query)
 #   print(ng_url)
   cert <- system.file("CurlSSL/cacert.pem", package = "RCurl")
-  html <- strsplit(getURL(ng_url, cainfo = cert, followlocation = TRUE), "\n", perl=TRUE)[[1]]
+  html <- strsplit(content(GET(ng_url, config(cainfo = cert)), "text"), "\n", perl=TRUE)[[1]]
   if (html[1] == "Please try again later.") stop('Server busy, answered "Please try again later."')
   result <- ngram_parse(html)
 #   browser()


### PR DESCRIPTION
The rCURL:getURL call was causing a redirect loop whenever a phrase had no match in the corpus, leading to Google responding with a 'sever is busy' error. I encountered this problem on both Windows 10 and Debian. I resolved this by replacing the with the same call in the httr library. I've used it over the weekend, and it seems to work fine now.